### PR TITLE
feat: show better errors when passing wrong contructs to Lumigo.trace*

### DIFF
--- a/API.md
+++ b/API.md
@@ -173,27 +173,27 @@ Whether to automatically trace all the Node.js and Python Lambda functions in th
 
 ---
 
-### TraceEcsServiceDefinitionProps <a name="TraceEcsServiceDefinitionProps" id="@lumigo/cdk-constructs-v2.TraceEcsServiceDefinitionProps"></a>
+### TraceEcsScheduledTaskProps <a name="TraceEcsScheduledTaskProps" id="@lumigo/cdk-constructs-v2.TraceEcsScheduledTaskProps"></a>
 
-#### Initializer <a name="Initializer" id="@lumigo/cdk-constructs-v2.TraceEcsServiceDefinitionProps.Initializer"></a>
+#### Initializer <a name="Initializer" id="@lumigo/cdk-constructs-v2.TraceEcsScheduledTaskProps.Initializer"></a>
 
 ```typescript
-import { TraceEcsServiceDefinitionProps } from '@lumigo/cdk-constructs-v2'
+import { TraceEcsScheduledTaskProps } from '@lumigo/cdk-constructs-v2'
 
-const traceEcsServiceDefinitionProps: TraceEcsServiceDefinitionProps = { ... }
+const traceEcsScheduledTaskProps: TraceEcsScheduledTaskProps = { ... }
 ```
 
 #### Properties <a name="Properties" id="Properties"></a>
 
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
-| <code><a href="#@lumigo/cdk-constructs-v2.TraceEcsServiceDefinitionProps.property.applyAutoTraceTag">applyAutoTraceTag</a></code> | <code>boolean</code> | Whether the Lumigo CDK constructs should automatically add the `lumigo:auto-trace` AWS tag with the version of the construct in use. |
-| <code><a href="#@lumigo/cdk-constructs-v2.TraceEcsServiceDefinitionProps.property.lumigoAutoTraceImage">lumigoAutoTraceImage</a></code> | <code>string</code> | Which container image to use to instrument ECS workloads. |
-| <code><a href="#@lumigo/cdk-constructs-v2.TraceEcsServiceDefinitionProps.property.lumigoTag">lumigoTag</a></code> | <code>string</code> | Which Lumigo tag to apply to your instrumented Lambda functions and ECS workloads. |
+| <code><a href="#@lumigo/cdk-constructs-v2.TraceEcsScheduledTaskProps.property.applyAutoTraceTag">applyAutoTraceTag</a></code> | <code>boolean</code> | Whether the Lumigo CDK constructs should automatically add the `lumigo:auto-trace` AWS tag with the version of the construct in use. |
+| <code><a href="#@lumigo/cdk-constructs-v2.TraceEcsScheduledTaskProps.property.lumigoAutoTraceImage">lumigoAutoTraceImage</a></code> | <code>string</code> | Which container image to use to instrument ECS workloads. |
+| <code><a href="#@lumigo/cdk-constructs-v2.TraceEcsScheduledTaskProps.property.lumigoTag">lumigoTag</a></code> | <code>string</code> | Which Lumigo tag to apply to your instrumented Lambda functions and ECS workloads. |
 
 ---
 
-##### `applyAutoTraceTag`<sup>Optional</sup> <a name="applyAutoTraceTag" id="@lumigo/cdk-constructs-v2.TraceEcsServiceDefinitionProps.property.applyAutoTraceTag"></a>
+##### `applyAutoTraceTag`<sup>Optional</sup> <a name="applyAutoTraceTag" id="@lumigo/cdk-constructs-v2.TraceEcsScheduledTaskProps.property.applyAutoTraceTag"></a>
 
 ```typescript
 public readonly applyAutoTraceTag: boolean;
@@ -206,7 +206,7 @@ Whether the Lumigo CDK constructs should automatically add the `lumigo:auto-trac
 
 ---
 
-##### `lumigoAutoTraceImage`<sup>Optional</sup> <a name="lumigoAutoTraceImage" id="@lumigo/cdk-constructs-v2.TraceEcsServiceDefinitionProps.property.lumigoAutoTraceImage"></a>
+##### `lumigoAutoTraceImage`<sup>Optional</sup> <a name="lumigoAutoTraceImage" id="@lumigo/cdk-constructs-v2.TraceEcsScheduledTaskProps.property.lumigoAutoTraceImage"></a>
 
 ```typescript
 public readonly lumigoAutoTraceImage: string;
@@ -224,7 +224,73 @@ The default value is the latest tag at the time of release of this version of th
 
 ---
 
-##### `lumigoTag`<sup>Optional</sup> <a name="lumigoTag" id="@lumigo/cdk-constructs-v2.TraceEcsServiceDefinitionProps.property.lumigoTag"></a>
+##### `lumigoTag`<sup>Optional</sup> <a name="lumigoTag" id="@lumigo/cdk-constructs-v2.TraceEcsScheduledTaskProps.property.lumigoTag"></a>
+
+```typescript
+public readonly lumigoTag: string;
+```
+
+- *Type:* string
+
+Which Lumigo tag to apply to your instrumented Lambda functions and ECS workloads.
+
+Lumigo Tags add dimension to your Lambda functions so that they can be identified, managed, organized, searched for, and filtered in Lumigo.
+For more information on Lumigo tags, refer to the [Lumigo tokens](https://docs.lumigo.io/docs/tags) documentation.
+
+---
+
+### TraceEcsServiceProps <a name="TraceEcsServiceProps" id="@lumigo/cdk-constructs-v2.TraceEcsServiceProps"></a>
+
+#### Initializer <a name="Initializer" id="@lumigo/cdk-constructs-v2.TraceEcsServiceProps.Initializer"></a>
+
+```typescript
+import { TraceEcsServiceProps } from '@lumigo/cdk-constructs-v2'
+
+const traceEcsServiceProps: TraceEcsServiceProps = { ... }
+```
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#@lumigo/cdk-constructs-v2.TraceEcsServiceProps.property.applyAutoTraceTag">applyAutoTraceTag</a></code> | <code>boolean</code> | Whether the Lumigo CDK constructs should automatically add the `lumigo:auto-trace` AWS tag with the version of the construct in use. |
+| <code><a href="#@lumigo/cdk-constructs-v2.TraceEcsServiceProps.property.lumigoAutoTraceImage">lumigoAutoTraceImage</a></code> | <code>string</code> | Which container image to use to instrument ECS workloads. |
+| <code><a href="#@lumigo/cdk-constructs-v2.TraceEcsServiceProps.property.lumigoTag">lumigoTag</a></code> | <code>string</code> | Which Lumigo tag to apply to your instrumented Lambda functions and ECS workloads. |
+
+---
+
+##### `applyAutoTraceTag`<sup>Optional</sup> <a name="applyAutoTraceTag" id="@lumigo/cdk-constructs-v2.TraceEcsServiceProps.property.applyAutoTraceTag"></a>
+
+```typescript
+public readonly applyAutoTraceTag: boolean;
+```
+
+- *Type:* boolean
+- *Default:* true
+
+Whether the Lumigo CDK constructs should automatically add the `lumigo:auto-trace` AWS tag with the version of the construct in use.
+
+---
+
+##### `lumigoAutoTraceImage`<sup>Optional</sup> <a name="lumigoAutoTraceImage" id="@lumigo/cdk-constructs-v2.TraceEcsServiceProps.property.lumigoAutoTraceImage"></a>
+
+```typescript
+public readonly lumigoAutoTraceImage: string;
+```
+
+- *Type:* string
+
+Which container image to use to instrument ECS workloads.
+
+Use a valid, full image name of the [`lumigo/lumigo-autotrace` image](https://gallery.ecr.aws/lumigo/lumigo-autotrace), e.g., `public.ecr.aws/lumigo/lumigo-autotrace:v14`.
+
+This property is exposed to support two use-cases: pinning a specific tag of the `lumigo/lumigo-autotrace` image, or supporting use-cases where Amazon ECS will not be able to pull from the Amazon ECS Public Gallery registry.
+The available tags are listed on the [`lumigo/lumigo-autotrace` Amazon ECR Public Gallery](https://gallery.ecr.aws/lumigo/lumigo-autotrace) page.
+The default value is the latest tag at the time of release of this version of the Lumigo CDK constructs: [default `lumigo/lumigo-autotrace` image](./src/lumigo_autotrace_image.json)
+
+---
+
+##### `lumigoTag`<sup>Optional</sup> <a name="lumigoTag" id="@lumigo/cdk-constructs-v2.TraceEcsServiceProps.property.lumigoTag"></a>
 
 ```typescript
 public readonly lumigoTag: string;
@@ -416,6 +482,7 @@ new Lumigo(props: LumigoProps)
 | **Name** | **Description** |
 | --- | --- |
 | <code><a href="#@lumigo/cdk-constructs-v2.Lumigo.asEcsExtension">asEcsExtension</a></code> | This method returns a wrapper that can be used in conjunction with the {@link https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_ecs.TaskDefinition.html#addwbrextensionextension\|TaskDefinition.addExtension} method. The effect is the same as using the {@link Lumigo#traceEcsTaskDefinition} method on the `TaskDefinition` on which you would invoke `TaskDefinition.addExtension`. |
+| <code><a href="#@lumigo/cdk-constructs-v2.Lumigo.traceEcsScheduledTask">traceEcsScheduledTask</a></code> | Apply Lumigo autotracing for Java, Node.js and Python applications deployed through the provided ECS ScheduledTask construct. |
 | <code><a href="#@lumigo/cdk-constructs-v2.Lumigo.traceEcsService">traceEcsService</a></code> | Apply Lumigo autotracing for Java, Node.js and Python applications deployed through the provided ECS Service construct. |
 | <code><a href="#@lumigo/cdk-constructs-v2.Lumigo.traceEcsTaskDefinition">traceEcsTaskDefinition</a></code> | Apply Lumigo autotracing for Java, Node.js and Python applications deployed through the provided `TaskDefinition`. If the ECS workload does not contain Java, Node.js or Python applications, no distributed-tracing data will be reported to Lumigo. |
 | <code><a href="#@lumigo/cdk-constructs-v2.Lumigo.traceEverything">traceEverything</a></code> | *No description.* |
@@ -432,37 +499,57 @@ public asEcsExtension(): ITaskDefinitionExtension
 
 This method returns a wrapper that can be used in conjunction with the {@link https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_ecs.TaskDefinition.html#addwbrextensionextension|TaskDefinition.addExtension} method. The effect is the same as using the {@link Lumigo#traceEcsTaskDefinition} method on the `TaskDefinition` on which you would invoke `TaskDefinition.addExtension`.
 
+##### `traceEcsScheduledTask` <a name="traceEcsScheduledTask" id="@lumigo/cdk-constructs-v2.Lumigo.traceEcsScheduledTask"></a>
+
+```typescript
+public traceEcsScheduledTask(scheduledTask: ScheduledEc2Task | ScheduledFargateTask, props?: TraceEcsScheduledTaskProps): void
+```
+
+Apply Lumigo autotracing for Java, Node.js and Python applications deployed through the provided ECS ScheduledTask construct.
+
+###### `scheduledTask`<sup>Required</sup> <a name="scheduledTask" id="@lumigo/cdk-constructs-v2.Lumigo.traceEcsScheduledTask.parameter.scheduledTask"></a>
+
+- *Type:* aws-cdk-lib.aws_ecs_patterns.ScheduledEc2Task | aws-cdk-lib.aws_ecs_patterns.ScheduledFargateTask
+
+---
+
+###### `props`<sup>Optional</sup> <a name="props" id="@lumigo/cdk-constructs-v2.Lumigo.traceEcsScheduledTask.parameter.props"></a>
+
+- *Type:* <a href="#@lumigo/cdk-constructs-v2.TraceEcsScheduledTaskProps">TraceEcsScheduledTaskProps</a>
+
+---
+
 ##### `traceEcsService` <a name="traceEcsService" id="@lumigo/cdk-constructs-v2.Lumigo.traceEcsService"></a>
 
 ```typescript
-public traceEcsService(service: Ec2Service | FargateService | QueueProcessingEc2Service | QueueProcessingFargateService | NetworkLoadBalancedEc2Service | NetworkLoadBalancedFargateService | ApplicationLoadBalancedEc2Service | ApplicationLoadBalancedFargateService | ScheduledEc2Task | ScheduledFargateTask | ApplicationMultipleTargetGroupsEc2Service | ApplicationMultipleTargetGroupsFargateService | NetworkMultipleTargetGroupsEc2Service | NetworkMultipleTargetGroupsFargateService, props?: TraceEcsServiceDefinitionProps): void
+public traceEcsService(service: Ec2Service | FargateService | QueueProcessingEc2Service | QueueProcessingFargateService | NetworkLoadBalancedEc2Service | NetworkLoadBalancedFargateService | ApplicationLoadBalancedEc2Service | ApplicationLoadBalancedFargateService | ApplicationMultipleTargetGroupsEc2Service | ApplicationMultipleTargetGroupsFargateService | NetworkMultipleTargetGroupsEc2Service | NetworkMultipleTargetGroupsFargateService, props?: TraceEcsServiceProps): void
 ```
 
 Apply Lumigo autotracing for Java, Node.js and Python applications deployed through the provided ECS Service construct.
 
 ###### `service`<sup>Required</sup> <a name="service" id="@lumigo/cdk-constructs-v2.Lumigo.traceEcsService.parameter.service"></a>
 
-- *Type:* aws-cdk-lib.aws_ecs.Ec2Service | aws-cdk-lib.aws_ecs.FargateService | aws-cdk-lib.aws_ecs_patterns.QueueProcessingEc2Service | aws-cdk-lib.aws_ecs_patterns.QueueProcessingFargateService | aws-cdk-lib.aws_ecs_patterns.NetworkLoadBalancedEc2Service | aws-cdk-lib.aws_ecs_patterns.NetworkLoadBalancedFargateService | aws-cdk-lib.aws_ecs_patterns.ApplicationLoadBalancedEc2Service | aws-cdk-lib.aws_ecs_patterns.ApplicationLoadBalancedFargateService | aws-cdk-lib.aws_ecs_patterns.ScheduledEc2Task | aws-cdk-lib.aws_ecs_patterns.ScheduledFargateTask | aws-cdk-lib.aws_ecs_patterns.ApplicationMultipleTargetGroupsEc2Service | aws-cdk-lib.aws_ecs_patterns.ApplicationMultipleTargetGroupsFargateService | aws-cdk-lib.aws_ecs_patterns.NetworkMultipleTargetGroupsEc2Service | aws-cdk-lib.aws_ecs_patterns.NetworkMultipleTargetGroupsFargateService
+- *Type:* aws-cdk-lib.aws_ecs.Ec2Service | aws-cdk-lib.aws_ecs.FargateService | aws-cdk-lib.aws_ecs_patterns.QueueProcessingEc2Service | aws-cdk-lib.aws_ecs_patterns.QueueProcessingFargateService | aws-cdk-lib.aws_ecs_patterns.NetworkLoadBalancedEc2Service | aws-cdk-lib.aws_ecs_patterns.NetworkLoadBalancedFargateService | aws-cdk-lib.aws_ecs_patterns.ApplicationLoadBalancedEc2Service | aws-cdk-lib.aws_ecs_patterns.ApplicationLoadBalancedFargateService | aws-cdk-lib.aws_ecs_patterns.ApplicationMultipleTargetGroupsEc2Service | aws-cdk-lib.aws_ecs_patterns.ApplicationMultipleTargetGroupsFargateService | aws-cdk-lib.aws_ecs_patterns.NetworkMultipleTargetGroupsEc2Service | aws-cdk-lib.aws_ecs_patterns.NetworkMultipleTargetGroupsFargateService
 
 ---
 
 ###### `props`<sup>Optional</sup> <a name="props" id="@lumigo/cdk-constructs-v2.Lumigo.traceEcsService.parameter.props"></a>
 
-- *Type:* <a href="#@lumigo/cdk-constructs-v2.TraceEcsServiceDefinitionProps">TraceEcsServiceDefinitionProps</a>
+- *Type:* <a href="#@lumigo/cdk-constructs-v2.TraceEcsServiceProps">TraceEcsServiceProps</a>
 
 ---
 
 ##### `traceEcsTaskDefinition` <a name="traceEcsTaskDefinition" id="@lumigo/cdk-constructs-v2.Lumigo.traceEcsTaskDefinition"></a>
 
 ```typescript
-public traceEcsTaskDefinition(taskDefinition: TaskDefinition, props?: TraceEcsTaskDefinitionProps): void
+public traceEcsTaskDefinition(taskDefinition: Ec2TaskDefinition | FargateTaskDefinition, props?: TraceEcsTaskDefinitionProps): void
 ```
 
 Apply Lumigo autotracing for Java, Node.js and Python applications deployed through the provided `TaskDefinition`. If the ECS workload does not contain Java, Node.js or Python applications, no distributed-tracing data will be reported to Lumigo.
 
 ###### `taskDefinition`<sup>Required</sup> <a name="taskDefinition" id="@lumigo/cdk-constructs-v2.Lumigo.traceEcsTaskDefinition.parameter.taskDefinition"></a>
 
-- *Type:* aws-cdk-lib.aws_ecs.TaskDefinition
+- *Type:* aws-cdk-lib.aws_ecs.Ec2TaskDefinition | aws-cdk-lib.aws_ecs.FargateTaskDefinition
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -220,6 +220,46 @@ const stack = new NodejsStack(app, 'NodejsTestStack', {
 app.synth();
 ```
 
+### Instrumenting single ECS scheduled task
+
+```typescript
+import { Lumigo } from '@lumigo/cdk-constructs-v2';
+import { App, SecretValue, Stack, StackProps } from 'aws-cdk-lib';
+import { ScheduledFargateTask } from 'aws-cdk-lib/aws-ecs-patterns';
+import { Construct } from 'constructs';
+
+interface NodejsStackProps extends StackProps {
+  readonly lumigo: Lumigo;
+}
+
+export class NodejsStack extends Stack {
+
+    constructor(scope: Construct, id: string, props: NodejsStackProps = {}) {
+        super(scope, id, props);
+
+        const scheduledTask = new ScheduledFargateTask(this, 'MyFargateScheduledTask', {
+            ...
+        });
+
+        props.lumigo.traceEcsScheduledTask(scheduledTask);
+    }
+
+}
+
+const app = new App();
+
+const lumigo = new Lumigo({lumigoToken:SecretValue.secretsManager('LumigoToken')});
+
+const stack = new NodejsStack(app, 'NodejsTestStack', {
+    env: {
+        region: 'eu-central-1',
+    },
+    lumigo,
+}); 
+
+app.synth();
+```
+
 ### Instrumenting single ECS task definitions
 
 Instrumenting at the level of the Amazon ECS task definition enables you to share the instrumented task definition across multiple ECS services: 

--- a/test/lumigo-type-hints.test.ts
+++ b/test/lumigo-type-hints.test.ts
@@ -1,0 +1,446 @@
+import { App, Duration, SecretValue, Stack } from 'aws-cdk-lib';
+import { Schedule } from 'aws-cdk-lib/aws-applicationautoscaling';
+import { Cluster, EcrImage, FargateService, FargateTaskDefinition } from 'aws-cdk-lib/aws-ecs';
+import { ApplicationLoadBalancedFargateService, ScheduledFargateTask } from 'aws-cdk-lib/aws-ecs-patterns';
+import { Code, Function, Runtime } from 'aws-cdk-lib/aws-lambda';
+import { Lumigo } from '../src';
+
+describe('When misuing the Lumigo trace* methods passing the wrong construct, should throw understandable errors', () => {
+
+  describe('when invoking "traceEverything" with in input', () => {
+
+    test('a Function', () => {
+      const app = new App();
+      const stack = new Stack(app, 'test-stack');
+      const f = new Function(stack, 'TestFunction', {
+        code: Code.fromInline('const foo = "bar"'),
+        handler: 'index/foo',
+        runtime: Runtime.NODEJS_16_X,
+      });
+
+      expect(() => {
+        new Lumigo({
+          lumigoToken: SecretValue.unsafePlainText('xxx'),
+        }).traceEverything(f as any as App);
+      }).toThrow('Lumigo.traceEverything needs a App as input; are you maybe looking for Lumigo.traceLambda instead?');
+    });
+
+    test('an ECS TaskDefinition', () => {
+      const app = new App();
+      const stack = new Stack(app, 'test-stack');
+
+      expect(() => {
+        new Lumigo({
+          lumigoToken: SecretValue.unsafePlainText('xxx'),
+        }).traceEverything(new FargateTaskDefinition(stack, 'TestDefinition', {}) as any as App);
+      }).toThrow('Lumigo.traceEverything needs a App as input; are you maybe looking for Lumigo.traceEcsTaskDefinition instead?');
+    });
+
+    test('an ECS ScheduledTask', () => {
+      const app = new App();
+      const stack = new Stack(app, 'test-stack');
+
+      const cluster = new Cluster(stack, 'TestCluster', {
+        clusterName: 'TestCluster',
+      });
+
+      const taskDefinition = new FargateTaskDefinition(stack, 'TestDefinition', {});
+      taskDefinition.addContainer('app', {
+        image: EcrImage.fromRegistry('docker.io/library/hello-world', {}),
+        environment: {
+          OTEL_SERVICE_NAME: 'http-server', // This will be the service name in Lumigo
+          LUMIGO_DEBUG_SPANDUMP: '/dev/stdout',
+        },
+        portMappings: [{
+          containerPort: 8443,
+        }],
+      });
+
+      const scheduledTask = new ScheduledFargateTask(stack, 'test-task', {
+        cluster,
+        scheduledFargateTaskDefinitionOptions: {
+          taskDefinition,
+        },
+        schedule: Schedule.rate(Duration.days(1)),
+      });
+
+      expect(() => {
+        new Lumigo({
+          lumigoToken: SecretValue.unsafePlainText('xxx'),
+        }).traceEverything(scheduledTask as any as App);
+      }).toThrow('Lumigo.traceEverything needs a App as input; are you maybe looking for Lumigo.traceEcsScheduledTask instead?');
+    });
+
+    test('an ECS Service', () => {
+      const app = new App();
+      const stack = new Stack(app, 'test-stack');
+
+      const cluster = new Cluster(stack, 'TestCluster', {
+        clusterName: 'TestCluster',
+      });
+
+      const taskDefinition = new FargateTaskDefinition(stack, 'TestDefinition', {});
+      taskDefinition.addContainer('app', {
+        image: EcrImage.fromRegistry('docker.io/library/hello-world', {}),
+        environment: {
+          OTEL_SERVICE_NAME: 'http-server', // This will be the service name in Lumigo
+          LUMIGO_DEBUG_SPANDUMP: '/dev/stdout',
+        },
+        portMappings: [{
+          containerPort: 8443,
+        }],
+      });
+
+      const service = new ApplicationLoadBalancedFargateService(stack, 'TestService', {
+        cluster,
+        taskDefinition,
+      });
+
+      expect(() => {
+        new Lumigo({
+          lumigoToken: SecretValue.unsafePlainText('xxx'),
+        }).traceEverything(service as any as App);
+      }).toThrow('Lumigo.traceEverything needs a App as input; are you maybe looking for Lumigo.traceEcsService instead?');
+    });
+
+  });
+
+  describe('when invoking "traceLambda" with in input', () => {
+
+    test('a CDK app', () => {
+      const app = new App();
+
+      expect(() => {
+        new Lumigo({
+          lumigoToken: SecretValue.unsafePlainText('xxx'),
+        }).traceLambda(app as any as Function);
+      }).toThrow('Lumigo.traceLambda needs a Function as input; are you maybe looking for Lumigo.traceEverything instead?');
+    });
+
+    test('an ECS TaskDefinition', () => {
+      const app = new App();
+      const stack = new Stack(app, 'test-stack');
+
+      expect(() => {
+        new Lumigo({
+          lumigoToken: SecretValue.unsafePlainText('xxx'),
+        }).traceLambda(new FargateTaskDefinition(stack, 'TestDefinition', {}) as any as Function);
+      }).toThrow('Lumigo.traceLambda needs a Function as input; are you maybe looking for Lumigo.traceEcsTaskDefinition instead?');
+    });
+
+    test('an ECS ScheduledTask', () => {
+      const app = new App();
+      const stack = new Stack(app, 'test-stack');
+
+      const cluster = new Cluster(stack, 'TestCluster', {
+        clusterName: 'TestCluster',
+      });
+
+      const taskDefinition = new FargateTaskDefinition(stack, 'TestDefinition', {});
+      taskDefinition.addContainer('app', {
+        image: EcrImage.fromRegistry('docker.io/library/hello-world', {}),
+        environment: {
+          OTEL_SERVICE_NAME: 'http-server', // This will be the service name in Lumigo
+          LUMIGO_DEBUG_SPANDUMP: '/dev/stdout',
+        },
+        portMappings: [{
+          containerPort: 8443,
+        }],
+      });
+
+      const scheduledTask = new ScheduledFargateTask(stack, 'test-task', {
+        cluster,
+        scheduledFargateTaskDefinitionOptions: {
+          taskDefinition,
+        },
+        schedule: Schedule.rate(Duration.days(1)),
+      });
+
+      expect(() => {
+        new Lumigo({
+          lumigoToken: SecretValue.unsafePlainText('xxx'),
+        }).traceLambda(scheduledTask as any as Function);
+      }).toThrow('Lumigo.traceLambda needs a Function as input; are you maybe looking for Lumigo.traceEcsScheduledTask instead?');
+    });
+
+    test('an ECS Service', () => {
+      const app = new App();
+      const stack = new Stack(app, 'test-stack');
+
+      const cluster = new Cluster(stack, 'TestCluster', {
+        clusterName: 'TestCluster',
+      });
+
+      const taskDefinition = new FargateTaskDefinition(stack, 'TestDefinition', {});
+      taskDefinition.addContainer('app', {
+        image: EcrImage.fromRegistry('docker.io/library/hello-world', {}),
+        environment: {
+          OTEL_SERVICE_NAME: 'http-server', // This will be the service name in Lumigo
+          LUMIGO_DEBUG_SPANDUMP: '/dev/stdout',
+        },
+        portMappings: [{
+          containerPort: 8443,
+        }],
+      });
+
+      const service = new ApplicationLoadBalancedFargateService(stack, 'TestService', {
+        cluster,
+        taskDefinition,
+      });
+
+      expect(() => {
+        new Lumigo({
+          lumigoToken: SecretValue.unsafePlainText('xxx'),
+        }).traceLambda(service as any as Function);
+      }).toThrow('Lumigo.traceLambda needs a Function as input; are you maybe looking for Lumigo.traceEcsService instead?');
+    });
+
+  });
+
+  describe('when invoking "traceEcsTaskDefinition" with in input', () => {
+
+    test('a CDK app', () => {
+      const app = new App();
+
+      expect(() => {
+        new Lumigo({
+          lumigoToken: SecretValue.unsafePlainText('xxx'),
+        }).traceEcsTaskDefinition(app as any as FargateTaskDefinition);
+      }).toThrow('Lumigo.traceEcsTaskDefinition needs a TaskDefinition as input; are you maybe looking for Lumigo.traceEverything instead?');
+    });
+
+    test('a Function', () => {
+      const app = new App();
+      const stack = new Stack(app, 'test-stack');
+      const f = new Function(stack, 'TestFunction', {
+        code: Code.fromInline('const foo = "bar"'),
+        handler: 'index/foo',
+        runtime: Runtime.NODEJS_16_X,
+      });
+
+      expect(() => {
+        new Lumigo({
+          lumigoToken: SecretValue.unsafePlainText('xxx'),
+        }).traceEcsTaskDefinition(f as any as FargateTaskDefinition);
+      }).toThrow('Lumigo.traceEcsTaskDefinition needs a TaskDefinition as input; are you maybe looking for Lumigo.traceLambda instead?');
+    });
+
+    test('an ECS ScheduledTask', () => {
+      const app = new App();
+      const stack = new Stack(app, 'test-stack');
+
+      const cluster = new Cluster(stack, 'TestCluster', {
+        clusterName: 'TestCluster',
+      });
+
+      const taskDefinition = new FargateTaskDefinition(stack, 'TestDefinition', {});
+      taskDefinition.addContainer('app', {
+        image: EcrImage.fromRegistry('docker.io/library/hello-world', {}),
+        environment: {
+          OTEL_SERVICE_NAME: 'http-server', // This will be the service name in Lumigo
+          LUMIGO_DEBUG_SPANDUMP: '/dev/stdout',
+        },
+        portMappings: [{
+          containerPort: 8443,
+        }],
+      });
+
+      const scheduledTask = new ScheduledFargateTask(stack, 'test-task', {
+        cluster,
+        scheduledFargateTaskDefinitionOptions: {
+          taskDefinition,
+        },
+        schedule: Schedule.rate(Duration.days(1)),
+      });
+
+      expect(() => {
+        new Lumigo({
+          lumigoToken: SecretValue.unsafePlainText('xxx'),
+        }).traceEcsTaskDefinition(scheduledTask as any as FargateTaskDefinition);
+      }).toThrow('Lumigo.traceEcsTaskDefinition needs a TaskDefinition as input; are you maybe looking for Lumigo.traceEcsScheduledTask instead?');
+    });
+
+    test('an ECS Service', () => {
+      const app = new App();
+      const stack = new Stack(app, 'test-stack');
+
+      const cluster = new Cluster(stack, 'TestCluster', {
+        clusterName: 'TestCluster',
+      });
+
+      const taskDefinition = new FargateTaskDefinition(stack, 'TestDefinition', {});
+      taskDefinition.addContainer('app', {
+        image: EcrImage.fromRegistry('docker.io/library/hello-world', {}),
+        environment: {
+          OTEL_SERVICE_NAME: 'http-server', // This will be the service name in Lumigo
+          LUMIGO_DEBUG_SPANDUMP: '/dev/stdout',
+        },
+        portMappings: [{
+          containerPort: 8443,
+        }],
+      });
+
+      const service = new ApplicationLoadBalancedFargateService(stack, 'TestService', {
+        cluster,
+        taskDefinition,
+      });
+
+      expect(() => {
+        new Lumigo({
+          lumigoToken: SecretValue.unsafePlainText('xxx'),
+        }).traceEcsTaskDefinition(service as any as FargateTaskDefinition);
+      }).toThrow('Lumigo.traceEcsTaskDefinition needs a TaskDefinition as input; are you maybe looking for Lumigo.traceEcsService instead?');
+    });
+
+  });
+
+  describe('when invoking "traceEcsScheduledTask" with in input', () => {
+
+    test('a CDK app', () => {
+      const app = new App();
+
+      expect(() => {
+        new Lumigo({
+          lumigoToken: SecretValue.unsafePlainText('xxx'),
+        }).traceEcsScheduledTask(app as any as ScheduledFargateTask);
+      }).toThrow('Lumigo.traceEcsScheduledTask needs a ScheduledEc2Task or ScheduledFargateTask as input; are you maybe looking for Lumigo.traceEverything instead?');
+    });
+
+    test('a Function', () => {
+      const app = new App();
+      const stack = new Stack(app, 'test-stack');
+      const f = new Function(stack, 'TestFunction', {
+        code: Code.fromInline('const foo = "bar"'),
+        handler: 'index/foo',
+        runtime: Runtime.NODEJS_16_X,
+      });
+
+      expect(() => {
+        new Lumigo({
+          lumigoToken: SecretValue.unsafePlainText('xxx'),
+        }).traceEcsScheduledTask(f as any as ScheduledFargateTask);
+      }).toThrow('Lumigo.traceEcsScheduledTask needs a ScheduledEc2Task or ScheduledFargateTask as input; are you maybe looking for Lumigo.traceLambda instead?');
+    });
+
+    test('an ECS TaskDefinition', () => {
+      const app = new App();
+      const stack = new Stack(app, 'test-stack');
+
+      expect(() => {
+        new Lumigo({
+          lumigoToken: SecretValue.unsafePlainText('xxx'),
+        }).traceEcsScheduledTask(new FargateTaskDefinition(stack, 'TestDefinition', {}) as any as ScheduledFargateTask);
+      }).toThrow('Lumigo.traceEcsScheduledTask needs a ScheduledEc2Task or ScheduledFargateTask as input; are you maybe looking for Lumigo.traceEcsTaskDefinition instead?');
+    });
+
+    test('an ECS Service', () => {
+      const app = new App();
+      const stack = new Stack(app, 'test-stack');
+
+      const cluster = new Cluster(stack, 'TestCluster', {
+        clusterName: 'TestCluster',
+      });
+
+      const taskDefinition = new FargateTaskDefinition(stack, 'TestDefinition', {});
+      taskDefinition.addContainer('app', {
+        image: EcrImage.fromRegistry('docker.io/library/hello-world', {}),
+        environment: {
+          OTEL_SERVICE_NAME: 'http-server', // This will be the service name in Lumigo
+          LUMIGO_DEBUG_SPANDUMP: '/dev/stdout',
+        },
+        portMappings: [{
+          containerPort: 8443,
+        }],
+      });
+
+      const service = new ApplicationLoadBalancedFargateService(stack, 'TestService', {
+        cluster,
+        taskDefinition,
+      });
+
+      expect(() => {
+        new Lumigo({
+          lumigoToken: SecretValue.unsafePlainText('xxx'),
+        }).traceEcsScheduledTask(service as any as ScheduledFargateTask);
+      }).toThrow('Lumigo.traceEcsScheduledTask needs a ScheduledEc2Task or ScheduledFargateTask as input; are you maybe looking for Lumigo.traceEcsService instead?');
+    });
+
+  });
+
+  describe('when invoking "traceEcsService" with in input', () => {
+
+    test('a CDK app', () => {
+      const app = new App();
+
+      expect(() => {
+        new Lumigo({
+          lumigoToken: SecretValue.unsafePlainText('xxx'),
+        }).traceEcsService(app as any as FargateService);
+      }).toThrow('Lumigo.traceEcsService needs a EcsService as input; are you maybe looking for Lumigo.traceEverything instead?');
+    });
+
+    test('a Function', () => {
+      const app = new App();
+      const stack = new Stack(app, 'test-stack');
+      const f = new Function(stack, 'TestFunction', {
+        code: Code.fromInline('const foo = "bar"'),
+        handler: 'index/foo',
+        runtime: Runtime.NODEJS_16_X,
+      });
+
+      expect(() => {
+        new Lumigo({
+          lumigoToken: SecretValue.unsafePlainText('xxx'),
+        }).traceEcsService(f as any as FargateService);
+      }).toThrow('Lumigo.traceEcsService needs a EcsService as input; are you maybe looking for Lumigo.traceLambda instead?');
+    });
+
+    test('an ECS TaskDefinition', () => {
+      const app = new App();
+      const stack = new Stack(app, 'test-stack');
+
+      expect(() => {
+        new Lumigo({
+          lumigoToken: SecretValue.unsafePlainText('xxx'),
+        }).traceEcsService(new FargateTaskDefinition(stack, 'TestDefinition', {}) as any as FargateService);
+      }).toThrow('Lumigo.traceEcsService needs a EcsService as input; are you maybe looking for Lumigo.traceEcsTaskDefinition instead?');
+    });
+
+    test('an ECS ScheduledTask', () => {
+      const app = new App();
+      const stack = new Stack(app, 'test-stack');
+
+      const cluster = new Cluster(stack, 'TestCluster', {
+        clusterName: 'TestCluster',
+      });
+
+      const taskDefinition = new FargateTaskDefinition(stack, 'TestDefinition', {});
+      taskDefinition.addContainer('app', {
+        image: EcrImage.fromRegistry('docker.io/library/hello-world', {}),
+        environment: {
+          OTEL_SERVICE_NAME: 'http-server', // This will be the service name in Lumigo
+          LUMIGO_DEBUG_SPANDUMP: '/dev/stdout',
+        },
+        portMappings: [{
+          containerPort: 8443,
+        }],
+      });
+
+      const scheduledTask = new ScheduledFargateTask(stack, 'test-task', {
+        cluster,
+        scheduledFargateTaskDefinitionOptions: {
+          taskDefinition,
+        },
+        schedule: Schedule.rate(Duration.days(1)),
+      });
+
+      expect(() => {
+        new Lumigo({
+          lumigoToken: SecretValue.unsafePlainText('xxx'),
+        }).traceEcsService(scheduledTask as any as FargateService);
+      }).toThrow('Lumigo.traceEcsService needs a EcsService as input; are you maybe looking for Lumigo.traceEcsScheduledTask instead?');
+    });
+
+  });
+
+});


### PR DESCRIPTION
Add type assertions to the `Lumigo.trace*` methods that throw error messages with helpful suggestions when typescript type validation is missing (e.g., using CDK with plain JS) or coerced.

Closes #16